### PR TITLE
ci: make publish workflow non-interactive

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,12 +39,28 @@ jobs:
           flutter pub get
           cd example && flutter pub get
 
-      - name: Publish (OIDC)
+      - name: Publish (OIDC with token fallback)
         if: github.event_name != 'workflow_dispatch'
-        run: flutter pub publish --force
+        env:
+          PUB_DEV_TOKEN: ${{ secrets.PUB_DEV_TOKEN }}
+        run: |
+          set -euo pipefail
 
-      - name: Publish (token)
+          if timeout 8m flutter pub publish --force; then
+            echo "Published with OIDC"
+            exit 0
+          fi
+
+          echo "OIDC publish failed or timed out, falling back to PUB_DEV_TOKEN"
+          dart pub token add https://pub.dev --env-var PUB_DEV_TOKEN
+          timeout 8m flutter pub publish --force
+
+      - name: Configure pub token
         if: github.event_name == 'workflow_dispatch'
         env:
           PUB_DEV_TOKEN: ${{ secrets.PUB_DEV_TOKEN }}
-        run: flutter pub publish --force
+        run: dart pub token add https://pub.dev --env-var PUB_DEV_TOKEN
+
+      - name: Publish (token)
+        if: github.event_name == 'workflow_dispatch'
+        run: timeout 8m flutter pub publish --force


### PR DESCRIPTION
## Summary
- make publish steps non-interactive in CI
- add timeout guards around publish commands to prevent hangs
- add token bootstrap for workflow_dispatch and token fallback for tag pushes

## Checklist
- [x] Tests updated or not needed
- [x]  clean (or no formatting changes needed)
- [x] Analyzing flutter_declarative_popups...
No issues found! clean
- [x]  updated (release PRs only)
- [x]  version bumped (release PRs only)
