### PR TITLE
ci: pass PUB_DEV_TOKEN to publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,4 +63,6 @@ jobs:
 
       - name: Publish (token)
         if: github.event_name == 'workflow_dispatch'
+        env:
+          PUB_DEV_TOKEN: ${{ secrets.PUB_DEV_TOKEN }}
         run: timeout 8m flutter pub publish --force


### PR DESCRIPTION
## Summary
- export PUB_DEV_TOKEN in Publish (token) step
- fixes workflow_dispatch publish failure where pub token credential was saved but env var missing at publish time

## Checklist
- [x] Tests updated or not needed
- [x] format/analyze not needed (workflow-only change)
- [x] CHANGELOG and pubspec not needed (no package code/version change)
