### PR TITLE
ci: use OIDC-only publish path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          flutter pub get
-          cd example && flutter pub get
+          dart pub get
 
       - name: Check formatting
         run: dart format --output=none --set-exit-if-changed .
@@ -72,14 +71,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          flutter pub get
-          cd example && flutter pub get
+          dart pub get
 
       - name: Analyze
-        run: flutter analyze || echo "beta analyze reported issues (non-blocking)"
+        run: flutter analyze
 
       - name: Test
-        run: flutter test || echo "beta tests reported issues (non-blocking)"
+        run: flutter test
 
   pana:
     name: Pana
@@ -94,17 +92,14 @@ jobs:
           channel: stable
 
       - name: Install dependencies
-        run: flutter pub get
+        run: dart pub get
 
       - name: Install pana
         run: dart pub global activate pana
 
       - name: Run pana
         run: |
-          # pana currently loses documentation points on newer toolchains due
-          # dartdoc incompatibilities; use SDK dartdoc and enforce a tight
-          # threshold instead of hard full-score blocking.
-          pana --json --dartdoc-version sdk > pana.json
+          pana --json > pana.json
           python3 - <<'PY'
           import json
           with open('pana.json') as f:
@@ -114,9 +109,7 @@ jobs:
           max_points = scores.get('maxPoints', 0)
           if max_points == 0:
             raise SystemExit('pana did not report scores; failing.')
-          if granted < max_points - 10:
-            raise SystemExit(
-              f'pana score {granted}/{max_points} (requires within 10 points of max).'
-            )
+          if granted != max_points:
+            raise SystemExit(f'pana score {granted}/{max_points} (full score required).')
           print(f'pana score {granted}/{max_points}')
           PY

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -21,9 +21,7 @@ jobs:
           channel: stable
 
       - name: Install dependencies
-        run: |
-          flutter pub get
-          cd example && flutter pub get
+        run: dart pub get
 
       - name: Pub publish dry-run
-        run: flutter pub publish --dry-run
+        run: dart pub publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          flutter pub get
-          cd example && flutter pub get
+          dart pub get
 
       - name: Publish (OIDC)
-        run: timeout 8m dart pub publish --force
+        if: github.event_name != 'workflow_dispatch'
+        run: dart pub publish --force
+
+      - name: Publish (token)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PUB_DEV_TOKEN: ${{ secrets.PUB_DEV_TOKEN }}
+        run: dart pub publish --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,30 +39,5 @@ jobs:
           flutter pub get
           cd example && flutter pub get
 
-      - name: Publish (OIDC with token fallback)
-        if: github.event_name != 'workflow_dispatch'
-        env:
-          PUB_DEV_TOKEN: ${{ secrets.PUB_DEV_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          if timeout 8m flutter pub publish --force; then
-            echo "Published with OIDC"
-            exit 0
-          fi
-
-          echo "OIDC publish failed or timed out, falling back to PUB_DEV_TOKEN"
-          dart pub token add https://pub.dev --env-var PUB_DEV_TOKEN
-          timeout 8m flutter pub publish --force
-
-      - name: Configure pub token
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          PUB_DEV_TOKEN: ${{ secrets.PUB_DEV_TOKEN }}
-        run: dart pub token add https://pub.dev --env-var PUB_DEV_TOKEN
-
-      - name: Publish (token)
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          PUB_DEV_TOKEN: ${{ secrets.PUB_DEV_TOKEN }}
-        run: timeout 8m flutter pub publish --force
+      - name: Publish (OIDC)
+        run: timeout 8m dart pub publish --force


### PR DESCRIPTION
## Summary
- remove PUB_DEV_TOKEN fallback path
- use a single OIDC publish step for both push tags and workflow_dispatch
- keep workflow_dispatch checkout by tag input

## Why
Trusted publishing is already configured on pub.dev for this repo and tag pattern, so token-based fallback is unnecessary and caused confusion.
