### PR TITLE
chore: release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.3] - 2026-02-17
+
+- Fixed GitHub Actions publish flow to use the official pub.dev trusted publisher OIDC workflow.
+- No public API changes.
+
 ## [0.3.2] - 2026-02-17
 
 - Maintenance release to publish through the updated GitHub release pipeline.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Material, Cupertino, and fully‑custom pop‑ups with type‑safe results, deep
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_declarative_popups: ^0.3.2
+  flutter_declarative_popups: ^0.3.3
 ```
 
 ```dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_declarative_popups
 description: Declarative popup routes for Navigator 2.0. Material, Cupertino, and custom popup pages with type-safe navigation and state restoration.
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/omar-hanafy/flutter_declarative_popups
 repository: https://github.com/omar-hanafy/flutter_declarative_popups
 issue_tracker: https://github.com/omar-hanafy/flutter_declarative_popups/issues


### PR DESCRIPTION
## Summary
- bump package version from 0.3.2 to 0.3.3
- update changelog for 0.3.3
- update README dependency snippet to 0.3.3

## Why
0.3.2 could not be published due publish workflow auth path issues. This release uses the fixed trusted publisher workflow and creates a fresh tag for a clean OIDC publish.
